### PR TITLE
CheckIf Fix

### DIFF
--- a/src/interpreter/check.js
+++ b/src/interpreter/check.js
@@ -58,11 +58,16 @@ function checkIf(args, env) {
 
   let cond = evalAST(args[0], env);
   let thenExp = args[1];
-  let elseExp = args[2];
 
-  // eval both the and else
-  evalAST(thenExp, env);
-  return evalAST(elseExp, env);
+  //else block exists
+  if(args.length === 3){
+    // eval both then and else
+    let elseExp = args[2];
+    evalAST(thenExp, env);
+    return evalAST(elseExp, env);
+  }else{
+    return evalAST(thenExp, env);
+  }
 }
 
 function checkAST(ast, env) {


### PR DESCRIPTION
Fix an issue where the checkIf method in the interpreter will always throw an exception when an if statement being 'checked' has no else clause. This occurs regardless of the validity of the if statement.